### PR TITLE
Verify camera ID when running dot in camera mode

### DIFF
--- a/dot/__main__.py
+++ b/dot/__main__.py
@@ -121,7 +121,9 @@ def main(
 ):
     """CLI entrypoint for dot."""
     # initialize dot
-    _dot = DOT(use_video=use_video, use_image=use_image, save_folder=save_folder)
+    _dot = DOT(
+        use_video=use_video, use_image=use_image, save_folder=save_folder, target=target
+    )
 
     # build dot
     option = _dot.build_option(

--- a/dot/commons/camera_utils.py
+++ b/dot/commons/camera_utils.py
@@ -13,6 +13,7 @@ from .cam.cam import draw_fps
 from .utils import TicToc, find_images_from_path
 from .video.videocaptureasync import VideoCaptureAsync
 
+
 def fetch_camera(target: int) -> VideoCaptureAsync:
     """Fetches a VideoCaptureAsync object.
 
@@ -27,8 +28,9 @@ def fetch_camera(target: int) -> VideoCaptureAsync:
     """
     try:
         return VideoCaptureAsync(target)
-    except:
+    except RuntimeError:
         raise ValueError(f"Camera {target} does not exist.")
+
 
 def camera_pipeline(
     cap: VideoCaptureAsync,
@@ -39,7 +41,7 @@ def camera_pipeline(
     post_process_image: Callable[[np.ndarray], np.ndarray],
     crop_size: int = 224,
     show_fps: bool = False,
-    **kwargs: Dict
+    **kwargs: Dict,
 ) -> None:
     """Open a webcam stream `target` and performs face-swap based on `source` image by frame.
 

--- a/dot/commons/camera_utils.py
+++ b/dot/commons/camera_utils.py
@@ -13,8 +13,25 @@ from .cam.cam import draw_fps
 from .utils import TicToc, find_images_from_path
 from .video.videocaptureasync import VideoCaptureAsync
 
+def fetch_camera(target: int) -> VideoCaptureAsync:
+    """Fetches a VideoCaptureAsync object.
+
+    Args:
+        target (int): Camera ID descriptor.
+
+    Raises:
+        ValueError: If camera ID descriptor is not valid.
+
+    Returns:
+        VideoCaptureAsync: VideoCaptureAsync object.
+    """
+    try:
+        return VideoCaptureAsync(target)
+    except:
+        raise ValueError(f"Camera {target} does not exist.")
 
 def camera_pipeline(
+    cap: VideoCaptureAsync,
     source: str,
     target: int,
     change_option: Callable[[np.ndarray], None],
@@ -27,6 +44,7 @@ def camera_pipeline(
     """Open a webcam stream `target` and performs face-swap based on `source` image by frame.
 
     Args:
+        cap (VideoCaptureAsync): VideoCaptureAsync object.
         source (str): Path to source image folder.
         target (int): Camera ID descriptor.
         change_option (Callable[[np.ndarray], None]): Set `source` arg as faceswap source image.
@@ -51,7 +69,6 @@ def camera_pipeline(
     img_a_align_crop = process_image(img_a_whole)
     img_a_align_crop = post_process_image(img_a_align_crop)
 
-    cap = VideoCaptureAsync(target)
     cap.start()
     ret, frame = cap.read()
     cv2.namedWindow("cam", cv2.WINDOW_GUI_NORMAL)

--- a/dot/commons/model_option.py
+++ b/dot/commons/model_option.py
@@ -12,7 +12,7 @@ import cv2
 import torch
 
 from ..gpen.face_enhancement import FaceEnhancement
-from .camera_utils import camera_pipeline
+from .camera_utils import camera_pipeline, fetch_camera
 from .utils import find_images_from_path, generate_random_file_idx, rand_idx_tuple
 from .video.video_utils import video_pipeline
 
@@ -180,8 +180,10 @@ class ModelOption(ABC):
             show_fps (bool, optional): Show FPS. Defaults to False.
         """
         with torch.no_grad():
+            cap = fetch_camera(target)
             self.create_model(opt_crop_size=opt_crop_size, **kwargs)
             camera_pipeline(
+                cap,
                 source,
                 target,
                 self.change_option,

--- a/dot/dot.py
+++ b/dot/dot.py
@@ -36,7 +36,6 @@ class DOT:
         use_video: bool = False,
         use_image: bool = False,
         save_folder: str = None,
-        target: Union[int, str] = None,
         *args,
         **kwargs,
     ):
@@ -47,7 +46,6 @@ class DOT:
             use_image (bool, optional): if True, use image-swap pipeline. Defaults to False.
             save_folder (str, optional): Output folder to store face-swaps and metadata file when `use_cam` is False.
                 Defaults to None.
-            target (Union[int, str], optional): Either `int` which indicates camera descriptor or target image file.
         """
         # init
         self.use_video = use_video
@@ -57,32 +55,9 @@ class DOT:
         # additional attributes
         self.use_cam = (not use_video) and (not use_image)
 
-        # verify if camera exists, if _dot.use_cam is True
-        if self.use_cam:
-            if isinstance(target, int):
-                if not self.cam_exists(target):
-                    raise ValueError(f"Camera {target} does not exist.")
-            else:
-                raise ValueError("target must be an integer when using camera.")
-
         # create output folder
         if self.save_folder and not Path(self.save_folder).exists():
             Path(self.save_folder).mkdir(parents=True, exist_ok=True)
-
-    def cam_exists(self, target: int) -> bool:
-        """Checks if camera ID exists.
-
-        Args:
-            target (int): Camera ID.
-
-        Returns:
-            bool: True if camera exists.
-        """
-        try:
-            _ = VideoCaptureAsync(target)
-            return True
-        except RuntimeError:
-            return False
 
     def build_option(
         self,

--- a/dot/dot.py
+++ b/dot/dot.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from .commons import ModelOption
-from .commons.video.videocaptureasync import VideoCaptureAsync
 from .faceswap_cv2 import FaceswapCVOption
 from .fomm import FOMMOption
 from .simswap import SimswapOption

--- a/tests/pipeline_test.py
+++ b/tests/pipeline_test.py
@@ -17,7 +17,7 @@ def fake_generate(self, option, source, target, show_fps=False, **kwargs):
 @mock.patch.object(DOT, "generate", fake_generate)
 class TestDotOptions(unittest.TestCase):
     def setUp(self):
-        self._dot = DOT(use_cam=False, save_folder="./tests")
+        self._dot = DOT(use_image=True, save_folder="./tests")
 
         self.faceswap_cv2_option = self._dot.faceswap_cv2(False, False, None)
 


### PR DESCRIPTION
This PR adds a check during dot initialisation to throw an exception if the entered camera id (`target`) is invalid.

## Changelog:

#### Added:

- ✨ added `fetch_camera()` method to `dot.commons.camera_utils` module: returns a `VideoCaptureAsync` object if camera ID is valid, else throws a `ValueError` exception

#### Updated:

- ⚡ updated `dot.commons.ModelOption::generate_from_camera()` to fetch `VideoCaptureAsync` object before loading models