### PR TITLE
Update README to Download Models from Github Release Binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,25 @@ pip install -e .
 
 ### Download Models
 
-There are 2 options for downloading the model weights:
-
-- GDrive: Download folder from [here](https://drive.google.com/drive/folders/1FX1QoXragN4aKJZFo2DLiDE8fqKHeXEB?usp=sharing), unzip and place the folder in the root directory of the repository.
-
-- `gdown`: Run the following command:
+-   Download GitHub Release binaries from [here](https://github.com/sensity-ai/dot/releases/tag/1.0.0) or use the following `wget` commands:
 
     ```bash
-    gdown https://drive.google.com/drive/folders/1FX1QoXragN4aKJZFo2DLiDE8fqKHeXEB -O ./saved_models --folder
+    wget https://github.com/sensity-ai/dot/releases/download/1.0.0/dot_model_checkpoints.z01 \
+    && wget https://github.com/sensity-ai/dot/releases/download/1.0.0/dot_model_checkpoints.z02 \
+    && wget https://github.com/sensity-ai/dot/releases/download/1.0.0/dot_model_checkpoints.zip
+    ```
+
+-   Unzip the binaries and place them in the root directory of the repository:
+
+    ```bash
+    zip -s 0 dot_model_checkpoints.zip --out saved_models.zip \
+    && unzip saved_models.zip
+    ```
+
+-   Clean up the downloaded binaries:
+
+    ```bash
+    rm -rf *.z*
     ```
 
 ## Usage

--- a/envs/environment-cpu.yaml
+++ b/envs/environment-cpu.yaml
@@ -9,6 +9,5 @@ dependencies:
     - pip:
           - torch==1.9.0
           - torchvision==0.10.0
-          - gdown==4.4.0
           - onnxruntime==1.9.0
           - -r ../requirements.txt

--- a/envs/environment-gpu.yaml
+++ b/envs/environment-gpu.yaml
@@ -9,5 +9,4 @@ dependencies:
     - pip:
           - llvmlite==0.36.0
           - onnxruntime-gpu==1.9.0
-          - gdown==4.4.0
           - -r ../requirements.txt


### PR DESCRIPTION
This PR updates the download instructions in the README to use GitHub Release Binaries instead of GDrive Link.

Models are now available on GitHub: https://github.com/sensity-ai/dot/releases/tag/1.0.0

## Changelog

#### Updated:

- 📝 updated download instructions in README

#### Removed:

- ➖ removed `gdown` dependency