### PR TITLE
Speed up SimSwap's `reverse2original`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @AjinkyaIndulkar made their first contribution in https://github.com/sensity-ai/dot/pull/19
 - @dependabot made their first contribution in https://github.com/sensity-ai/dot/pull/25
 - @vassilispapadop made their first contribution in https://github.com/sensity-ai/dot/pull/28
-- @vassilispapadop made their first contribution in https://github.com/sensity-ai/dot/pull/28
 - @ghassen1302 made their first contribution in https://github.com/sensity-ai/dot/pull/20
 
 ## [1.0.0] - 2022-06-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump numpy from 1.21.1 to 1.22.0 by @dependabot in https://github.com/sensity-ai/dot/pull/25
 - Update python version to 3.8 by @vassilispapadop in https://github.com/sensity-ai/dot/pull/28
 - Requirements changes now trigger CI by @giorgiop in https://github.com/sensity-ai/dot/pull/27
+- Speed up SimSwap's reverse2original by @AjinkyaIndulkar and @ghassen1302 in https://github.com/sensity-ai/dot/pull/20
 
 #### Fixed
 
@@ -43,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @AjinkyaIndulkar made their first contribution in https://github.com/sensity-ai/dot/pull/19
 - @dependabot made their first contribution in https://github.com/sensity-ai/dot/pull/25
 - @vassilispapadop made their first contribution in https://github.com/sensity-ai/dot/pull/28
+- @vassilispapadop made their first contribution in https://github.com/sensity-ai/dot/pull/28
+- @ghassen1302 made their first contribution in https://github.com/sensity-ai/dot/pull/20
 
 ## [1.0.0] - 2022-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New Contributors
 
 - @giorgiop made their first contribution in https://github.com/sensity-ai/dot/pull/6
+- @ghassen1302 made their first contribution in https://github.com/sensity-ai/dot/pull/6
 - @imgbot made their first contribution in https://github.com/sensity-ai/dot/pull/8
 - @AjinkyaIndulkar made their first contribution in https://github.com/sensity-ai/dot/pull/19
 - @dependabot made their first contribution in https://github.com/sensity-ai/dot/pull/25
 - @vassilispapadop made their first contribution in https://github.com/sensity-ai/dot/pull/28
-- @ghassen1302 made their first contribution in https://github.com/sensity-ai/dot/pull/20
 
 ## [1.0.0] - 2022-06-04
 

--- a/dot/commons/video/video_utils.py
+++ b/dot/commons/video/video_utils.py
@@ -99,7 +99,7 @@ def video_pipeline(
             ret, frame = cap.read()
             frame = cv2.flip(frame, 1)
             if ret is True:
-                result_frame = process_image(frame, crop_size=crop_size, **kwargs)  # type: ignore
+                result_frame = process_image(frame, use_cam=False, crop_size=crop_size, **kwargs)  # type: ignore
                 result_frame = post_process_image(result_frame, **kwargs)
                 video_writer.write(result_frame)
             else:

--- a/dot/simswap/option.py
+++ b/dot/simswap/option.py
@@ -156,7 +156,6 @@ class SimswapOption(ModelOption):
         """
 
         detect_results = self.detect_model.get(image, self.crop_size)
-
         if detect_results is not None:
             frame_align_crop_list = detect_results[0]
             frame_mat_list = detect_results[1]
@@ -188,6 +187,7 @@ class SimswapOption(ModelOption):
                 use_mask=self.use_mask,
                 norm=self.spNorm,
                 use_gpu=self.use_gpu,
+                use_cam=kwargs.get("use_cam", True),
             )
             return result_frame
         else:

--- a/dot/simswap/util/reverse2original.py
+++ b/dot/simswap/util/reverse2original.py
@@ -106,7 +106,6 @@ def reverse2wholeimage(
     use_mask=False,
     use_gpu=True,
 ):
-
     target_image_list = []
     img_mask_list = []
     if use_mask:
@@ -191,6 +190,9 @@ def reverse2wholeimage(
                         orisize,
                     )[..., ::-1]
         else:
+            swaped_img[swaped_img < 0] = 0
+            swaped_img = K.utils.image_to_tensor(swaped_img.copy())
+            swaped_img = swaped_img[None, ...].float()
             if use_gpu:
                 target_image = ko_transform.warp_affine(
                     swaped_img.cuda(),

--- a/dot/simswap/util/reverse2original.py
+++ b/dot/simswap/util/reverse2original.py
@@ -116,8 +116,6 @@ def reverse2wholeimage(
         smooth_mask = SoftErosion(kernel_size=17, threshold=0.9, iterations=7).to(
             device
         )
-    else:
-        pass
 
     img = K.utils.image_to_tensor(oriimg).float().to(device)
     img /= 255.0

--- a/dot/simswap/util/reverse2original.py
+++ b/dot/simswap/util/reverse2original.py
@@ -84,6 +84,8 @@ class SoftErosion(nn.Module):
 
 def postprocess(swapped_face, target, target_mask, smooth_mask, device):
 
+    target_mask = target_mask.float().mul_(1 / 255.0)
+
     face_mask_tensor = target_mask[0] + target_mask[1]
 
     soft_face_mask_tensor, _ = smooth_mask(face_mask_tensor.unsqueeze_(0).unsqueeze_(0))

--- a/dot/simswap/util/reverse2original.py
+++ b/dot/simswap/util/reverse2original.py
@@ -87,7 +87,6 @@ def postprocess(swapped_face, target, target_mask, smooth_mask, device):
     return result
 
 
-# TODO: use device instead of use_gpu
 def reverse2wholeimage(
     b_align_crop_tenor_list,
     swaped_imgs,

--- a/dot/simswap/util/reverse2original.py
+++ b/dot/simswap/util/reverse2original.py
@@ -122,6 +122,8 @@ def reverse2wholeimage(
     kernel_use_cam = torch.ones(5, 5).to(device)
     kernel_use_image = np.ones((40, 40), np.uint8)
     orisize = (oriimg.shape[0], oriimg.shape[1])
+    mat_rev_initial = torch.ones([3, 3]).to(device)
+    mat_rev_initial[2, :] = torch.tensor([0.0, 0.0, 1.0]).to(device)
     for swaped_img, mat, source_img in zip(swaped_imgs, mats, b_align_crop_tenor_list):
 
         img_white = torch.full((1, 3, crop_size, crop_size), 1.0, dtype=torch.float).to(
@@ -129,11 +131,9 @@ def reverse2wholeimage(
         )
 
         # invert the Affine transformation matrix
-        mat_rev = torch.ones([3, 3]).to(device)
-        mat_rev[0:2, :] = torch.tensor(mat).to(device)
-        mat_rev[2, :] = torch.tensor([0.0, 0.0, 1.0]).to(device)
+        mat_rev_initial[0:2, :] = torch.tensor(mat).to(device)
 
-        mat_rev = torch.linalg.inv(mat_rev)
+        mat_rev = torch.linalg.inv(mat_rev_initial)
         mat_rev = mat_rev[:2, :]
 
         mat_rev = mat_rev[None, ...]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click==8.0.2
 dlib==19.19.0
 face_alignment==1.3.3
+kornia==0.6.5
 numpy==1.21.1
 opencv_python==4.5.5.62
 opencv-contrib-python==4.5.5.62

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     click
     dlib
     face_alignment
+	kornia
     numpy
     opencv_python
     opencv-contrib-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     click
     dlib
     face_alignment
-	kornia
+    kornia
     numpy
     opencv_python
     opencv-contrib-python


### PR DESCRIPTION
## Description

This PR replaces use of `cv2.warpAffine` with `kornia.geometry.transform.warp_affine` to run tranformations on CUDA if `use_gpu=True`

Closes #3.

## Changelog

#### Added:

- ➕ added `kornia` dependency

#### Updated:

- ⚡ updated `dot.simswap.util.reverse2original.reverse2wholeimage` function to use `kornia.geometry.transform.warp_affine` for affine transformation on CUDA device
- Optimize the use of devices and clean numpy and torch conversions
