### PR TITLE
Use FOMM offline with driving video

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
         hooks:
           - id: black
 
-      - repo: https://gitlab.com/pycqa/flake8
-        rev: 4.0.1
+      - repo: https://github.com/PyCQA/flake8
+        rev: 6.0.0
         hooks:
           - id: flake8
             args: [--max-line-length=150, --extend-ignore=E203]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Update README and CONTRIBUTING by @giorgiop in https://github.com/sensity-ai/dot/pull/40
+* Fix config paths in additional scripts under `scripts/` folder by @Ghassen-Chaabouni in https://github.com/sensity-ai/dot/pull/43
+* Update README and add instructions for running dot with an Android emulator by @Ghassen-Chaabouni in https://github.com/sensity-ai/dot/pull/45
+
 ## [1.1.0] - 2022-07-27
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Supported methods:
     brew install ffmpeg cmake
     ```
 
+- Windows
+
+    no pre-requisites to be installed, skip this step
+
 ### Create Conda Environment
 
 > The instructions assumes that you have Miniconda installed on your machine. If you don't, you can refer to this [link](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) for installation instructions.
@@ -90,7 +94,7 @@ pip install -e .
 
 ### Download Models
 
--   Download GitHub Release binaries from [here](https://github.com/sensity-ai/dot/releases/tag/1.0.0) or use the following `wget` commands:
+- Download GitHub Release binaries from [here](https://github.com/sensity-ai/dot/releases/tag/1.0.0) or use the following `wget` commands:
 
     ```bash
     wget https://github.com/sensity-ai/dot/releases/download/1.0.0/dot_model_checkpoints.z01 \
@@ -98,14 +102,14 @@ pip install -e .
     && wget https://github.com/sensity-ai/dot/releases/download/1.0.0/dot_model_checkpoints.zip
     ```
 
--   Unzip the binaries and place them in the root directory of the repository:
+- Unzip the binaries and place them in the root directory of the repository:
 
     ```bash
     zip -s 0 dot_model_checkpoints.zip --out saved_models.zip \
     && unzip saved_models.zip
     ```
 
--   Clean up the downloaded binaries:
+- Clean up the downloaded binaries:
 
     ```bash
     rm -rf *.z*
@@ -226,6 +230,25 @@ Use the virtual camera with `OBS Studio`:
 - Click "Start Virtual Camera" button in the controls section
 - Select "OBS Cam" as default camera in the video settings of the application target of the injection
 
+## Run dot with an Android emulator
+
+If you are performing a test against a mobile app, virtual cameras are much harder to inject. An alternative is to use mobile emulators and still resort to virtual camera injection.
+
+- Run `dot`. Check [running dot](https://github.com/sensity-ai/dot#running-dot) for more information.
+
+- Run `OBS Studio` and set up the virtual camera. Check [virtual-camera-injection](https://github.com/sensity-ai/dot#virtual-camera-injection) for more information.
+
+- Download and Install [Genymotion](https://www.genymotion.com/download/).
+
+- Open Genymotion and set up the Android emulator.
+
+- Set up dot with the Android emulator:
+  - Open the Android emulator.
+  - Click on `camera` and select `OBS-Camera` as front and back cameras. A preview of the dot window should appear.
+  In case there is no preview, restart `OBS` and the emulator and try again.
+  If that didn't work, use a different virtual camera software like `e2eSoft VCam` or `ManyCam`.
+  - `dot` deepfake output should be now the emulator's phone camera.
+
 ## Speed
 
 Tested on a AMD Ryzen 5 2600 Six-Core Processor with one NVIDIA GeForce RTX 2070
@@ -278,11 +301,9 @@ If you have ideas for improving *dot*, feel free to open relevant Issues and PRs
 
 - **`dot` is very slow and I can't run it in real time**
 
-
 Make sure that you are running it on a GPU card by using the `--use_gpu` flag. CPU is not recommended.
 If you still find it too slow it may be because you running it on an old GPU model, with less than 8GB of RAM.
 
 - **Does `dot` only work with a webcam feed or also with a pre-recorded video?**
-
 
 You can use `dot` on a pre-recorded video file by [these scripts](docs/run_without_camera.md) or try it directly on [Colab](https://colab.research.google.com/github/sensity-ai/dot/blob/main/notebooks/colab_demo.ipynb).

--- a/configs/fomm.yaml
+++ b/configs/fomm.yaml
@@ -1,3 +1,4 @@
 ---
 swap_type: fomm
 model_path: ./saved_models/fomm/vox-adv-cpk.pth.tar
+head_pose: true

--- a/docs/run_without_camera.md
+++ b/docs/run_without_camera.md
@@ -4,11 +4,15 @@
 ## Using Images
 
 ```bash
-dot -c ./configs/simswap.yaml --target data/ --source "data/" --save_folder test_local --use_image --use_gpu
+dot -c ./configs/simswap.yaml --target data/ --source "data/" --save_folder test_local/ --use_image --use_gpu
 ```
 
 ```bash
 dot -c ./configs/faceswap_cv2.yaml --target data/ --source "data/" --save_folder test_local/ --use_image --use_gpu
+```
+
+```
+dot -c ./configs/fomm.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_video
 ```
 
 ## Faceswap images from directory (Simswap)

--- a/docs/run_without_camera.md
+++ b/docs/run_without_camera.md
@@ -11,6 +11,11 @@ dot -c ./configs/simswap.yaml --target data/ --source "data/" --save_folder test
 dot -c ./configs/faceswap_cv2.yaml --target data/ --source "data/" --save_folder test_local/ --use_image --use_gpu
 ```
 
+## Using Videos
+```
+dot -c ./configs/simswap.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_video
+```
+
 ```
 dot -c ./configs/fomm.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_video
 ```

--- a/docs/run_without_camera.md
+++ b/docs/run_without_camera.md
@@ -12,12 +12,13 @@ dot -c ./configs/faceswap_cv2.yaml --target data/ --source "data/" --save_folder
 ```
 
 ## Using Videos
+
 ```
-dot -c ./configs/simswap.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_video
+dot -c ./configs/simswap.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_gpu --use_video
 ```
 
 ```
-dot -c ./configs/fomm.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/ --use_video
+dot -c ./configs/fomm.yaml --target "/path/to/driving/video" --source "data/image.png"  --save_folder test_local/  --use_gpu --use_video
 ```
 
 ## Faceswap images from directory (Simswap)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -151,7 +151,7 @@ pre-commit==2.19.0
     # via dot (setup.cfg)
 prompt-toolkit==3.0.30
     # via ipython
-protobuf==3.20.1
+protobuf==3.20.2
     # via
     #   dot (setup.cfg)
     #   mediapipe

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ pillow==9.1.1
     #   matplotlib
     #   scikit-image
     #   torchvision
-protobuf==3.20.1
+protobuf==3.20.2
     # via
     #   dot (setup.cfg)
     #   mediapipe

--- a/src/dot/__main__.py
+++ b/src/dot/__main__.py
@@ -23,6 +23,7 @@ def run(
     gpen_type: str = None,
     gpen_path: str = "./saved_models/gpen",
     crop_size: int = 224,
+    head_pose: bool = False,
     save_folder: str = None,
     show_fps: bool = False,
     use_gpu: bool = False,
@@ -74,6 +75,7 @@ def run(
         arcface_model_path=arcface_model_path,
         checkpoints_dir=checkpoints_dir,
         opt_crop_size=crop_size,
+        head_pose=head_pose,
     )
 
 
@@ -212,6 +214,7 @@ def main(
         gpen_type=config.get("gpen_type", gpen_type),
         gpen_path=config.get("gpen_path", gpen_path),
         crop_size=config.get("crop_size", crop_size),
+        head_pose=config.get("head_pose", False),
         save_folder=save_folder,
         show_fps=show_fps,
         use_gpu=use_gpu,

--- a/src/dot/commons/model_option.py
+++ b/src/dot/commons/model_option.py
@@ -221,7 +221,9 @@ class ModelOption(ABC):
                 self.change_option,
                 self.process_image,
                 self.post_process_image,
+                self.crop_size,
                 limit,
+                **kwargs,
             )
 
     def post_process_image(self, image, **kwargs):

--- a/src/dot/commons/pose/head_pose.py
+++ b/src/dot/commons/pose/head_pose.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+import cv2
+import mediapipe as mp
+import numpy as np
+
+mp_face_mesh = mp.solutions.face_mesh
+face_mesh = mp_face_mesh.FaceMesh(
+    min_detection_confidence=0.5, min_tracking_confidence=0.5
+)
+mp_drawing = mp.solutions.drawing_utils
+
+
+def pose_estimation(
+    image: np.array, roll: int = 3, pitch: int = 3, yaw: int = 3
+) -> int:
+    """Given an image and desired roll, pitch and yaw angles, returns whether head pose estimation meets requirements.
+
+    Args:
+        image (np.array): Image to estimate head pose.
+        roll (int, optional): Rotation margin in X axis. Defaults to 3.
+        pitch (int, optional): Rotation margin in Y axis. Defaults to 3.
+        yaw (int, optional): Rotation margin in Z axis. Defaults to 3.
+
+    Returns:
+        int: _description_
+    """
+
+    results = face_mesh.process(image)
+    img_h, img_w, img_c = image.shape
+    face_3d = []
+    face_2d = []
+    if results.multi_face_landmarks:
+        for face_landmarks in results.multi_face_landmarks:
+            for idx, lm in enumerate(face_landmarks.landmark):
+                if (
+                    idx == 33
+                    or idx == 263
+                    or idx == 1
+                    or idx == 61
+                    or idx == 291
+                    or idx == 199
+                ):
+                    x, y = int(lm.x * img_w), int(lm.y * img_h)
+
+                    # get 2d coordinates
+                    face_2d.append([x, y])
+
+                    # get 3d coordinates
+                    face_3d.append([x, y, lm.z])
+
+            # convert to numpy
+            face_2d = np.array(face_2d, dtype=np.float64)
+            face_3d = np.array(face_3d, dtype=np.float64)
+
+            # camera matrix
+            focal_length = 1 * img_w
+            cam_matrix = np.array(
+                [[focal_length, 9, img_h / 2], [0, focal_length, img_w / 2], [0, 0, 1]]
+            )
+            # distortion
+            dist_matrix = np.zeros((4, 1), dtype=np.float64)
+            # solve pnp
+            success, rot_vec, trans_vec = cv2.solvePnP(
+                face_3d, face_2d, cam_matrix, dist_matrix
+            )
+            # rotational matrix
+            rmat, jac = cv2.Rodrigues(rot_vec)
+            # get angles
+            angles, mtxR, mtxQ, Qx, Qy, Qz = cv2.RQDecomp3x3(rmat)
+
+            # get rotation angles
+            x = angles[0] * 360
+            y = angles[1] * 360
+            z = angles[2] * 360
+
+            # head rotation in X axis
+            if x < -roll or x > roll:
+                return -1
+
+            # head rotation in Y axis
+            if y < -pitch or y > pitch:
+                return -1
+
+            # head rotation in Z axis
+            if z < -yaw or z > yaw:
+                return -1
+
+            return 0
+
+    return -1

--- a/src/dot/commons/pose/head_pose.py
+++ b/src/dot/commons/pose/head_pose.py
@@ -9,6 +9,16 @@ face_mesh = mp_face_mesh.FaceMesh(
 )
 mp_drawing = mp.solutions.drawing_utils
 
+# https://github.com/tensorflow/tfjs-models/blob/838611c02f51159afdd77469ce67f0e26b7bbb23/face-landmarks-detection/src/mediapipe-facemesh/keypoints.ts
+HEAD_POSE_LANDMARKS = [
+    33,
+    263,
+    1,
+    61,
+    291,
+    199,
+]
+
 
 def pose_estimation(
     image: np.array, roll: int = 3, pitch: int = 3, yaw: int = 3
@@ -16,7 +26,7 @@ def pose_estimation(
     """
     Adjusted from: https://github.com/niconielsen32/ComputerVision/blob/master/headPoseEstimation.py
     Given an image and desired `roll`, `pitch` and `yaw` angles, the method checks whether
-    estimatated head-pose meets requirements.
+    estimated head-pose meets requirements.
 
     Args:
         image: Image to estimate head pose.
@@ -35,14 +45,7 @@ def pose_estimation(
     if results.multi_face_landmarks:
         for face_landmarks in results.multi_face_landmarks:
             for idx, lm in enumerate(face_landmarks.landmark):
-                if (
-                    idx == 33
-                    or idx == 263
-                    or idx == 1
-                    or idx == 61
-                    or idx == 291
-                    or idx == 199
-                ):
+                if idx in HEAD_POSE_LANDMARKS:
                     x, y = int(lm.x * img_w), int(lm.y * img_h)
 
                     # get 2d coordinates

--- a/src/dot/commons/pose/head_pose.py
+++ b/src/dot/commons/pose/head_pose.py
@@ -9,7 +9,7 @@ face_mesh = mp_face_mesh.FaceMesh(
 )
 mp_drawing = mp.solutions.drawing_utils
 
-# https://github.com/tensorflow/tfjs-models/blob/838611c02f51159afdd77469ce67f0e26b7bbb23/face-landmarks-detection/src/mediapipe-facemesh/keypoints.ts
+# https://github.com/google/mediapipe/issues/1615
 HEAD_POSE_LANDMARKS = [
     33,
     263,

--- a/src/dot/commons/pose/head_pose.py
+++ b/src/dot/commons/pose/head_pose.py
@@ -13,16 +13,19 @@ mp_drawing = mp.solutions.drawing_utils
 def pose_estimation(
     image: np.array, roll: int = 3, pitch: int = 3, yaw: int = 3
 ) -> int:
-    """Given an image and desired roll, pitch and yaw angles, returns whether head pose estimation meets requirements.
+    """
+    Adjusted from: https://github.com/niconielsen32/ComputerVision/blob/master/headPoseEstimation.py
+    Given an image and desired `roll`, `pitch` and `yaw` angles, the method checks whether
+    estimatated head-pose meets requirements.
 
     Args:
-        image (np.array): Image to estimate head pose.
-        roll (int, optional): Rotation margin in X axis. Defaults to 3.
-        pitch (int, optional): Rotation margin in Y axis. Defaults to 3.
-        yaw (int, optional): Rotation margin in Z axis. Defaults to 3.
+        image: Image to estimate head pose.
+        roll: Rotation margin in X axis.
+        pitch: Rotation margin in Y axis.
+        yaw: Rotation margin in Z axis.
 
     Returns:
-        int: _description_
+        int: Success(0) or Fail(-1).
     """
 
     results = face_mesh.process(image)

--- a/src/dot/commons/utils.py
+++ b/src/dot/commons/utils.py
@@ -68,7 +68,7 @@ def expand_bbox(
     bbox, image_width, image_height, scale=None
 ) -> Tuple[int, int, int, int]:
     if scale is None:
-        raise ValueError("margin and scale are mutually exclusive parameter")
+        raise ValueError("scale parameter is none")
 
     x1, y1, x2, y2 = bbox
 

--- a/src/dot/commons/utils.py
+++ b/src/dot/commons/utils.py
@@ -11,6 +11,9 @@ from typing import Dict, List, Tuple
 import cv2
 import numpy as np
 
+SEED = 42
+np.random.seed(SEED)
+
 
 def log(*args, file=sys.stderr, **kwargs):
     time_str = f"{time.time():.6f}"
@@ -52,7 +55,7 @@ def find_files_from_path(path: str, ext: List, filter: str = None):
         [
             files.extend(glob.glob(path + "**/*." + e, recursive=True)) for e in ext  # type: ignore
         ]
-        random.shuffle(files)
+        np.random.shuffle(files)
 
         # filter
         if filter is not None:

--- a/src/dot/commons/utils.py
+++ b/src/dot/commons/utils.py
@@ -6,7 +6,7 @@ import random
 import sys
 import time
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import cv2
 import numpy as np
@@ -41,7 +41,7 @@ def find_images_from_path(path):
         return files
 
 
-def find_files_from_path(path: str, ext: List):
+def find_files_from_path(path: str, ext: List, filter: str = None):
     """
     @arguments:
         path              (str)     Parent directory of files
@@ -52,10 +52,39 @@ def find_files_from_path(path: str, ext: List):
         [
             files.extend(glob.glob(path + "**/*." + e, recursive=True)) for e in ext  # type: ignore
         ]
+        random.shuffle(files)
+
+        # filter
+        if filter is not None:
+            files = [file for file in files if filter in file]
+            print("Filtered files: ", len(files))
 
         return files
 
     return [path]
+
+
+def expand_bbox(
+    bbox, image_width, image_height, scale=None
+) -> Tuple[int, int, int, int]:
+    if scale is None:
+        raise ValueError("margin and scale are mutually exclusive parameter")
+
+    x1, y1, x2, y2 = bbox
+
+    center_x, center_y = (x1 + x2) // 2, (y1 + y2) // 2
+
+    size_bb = round(max(x2 - x1, y2 - y1) * scale)
+
+    # Check for out of bounds, x-y top left corner
+    x1 = max(int(center_x - size_bb // 2), 0)
+    y1 = max(int(center_y - size_bb // 2), 0)
+
+    # Check for too big bb size for given x, y
+    size_bb = min(image_width - x1, size_bb)
+    size_bb = min(image_height - y1, size_bb)
+
+    return (x1, y1, x1 + size_bb, y1 + size_bb)
 
 
 def rand_idx_tuple(source_len, target_len):

--- a/src/dot/commons/video/video_utils.py
+++ b/src/dot/commons/video/video_utils.py
@@ -54,10 +54,6 @@ def _crop_and_pose(
         image_rows,
     )
 
-    if rect_start_point is None or rect_end_point is None:
-        print("Relative location issue")
-        return -1
-
     xleft, ytop = rect_start_point
     xright, ybot = rect_end_point
 

--- a/src/dot/commons/video/video_utils.py
+++ b/src/dot/commons/video/video_utils.py
@@ -160,9 +160,6 @@ def video_pipeline(
         video_writer = cv2.VideoWriter(
             output_file, fourcc, fps, (frame_width, frame_height), True
         )
-        video_writer = cv2.VideoWriter(
-            output_file, fourcc, fps, (frame_width, frame_height), True
-        )
         print(
             f"Source: {source} \nTarget: {target} \nOutput: {output_file} \nFPS: {fps} \nTotal frames: {total_frames}"
         )

--- a/src/dot/commons/video/video_utils.py
+++ b/src/dot/commons/video/video_utils.py
@@ -83,7 +83,7 @@ def video_pipeline(
     change_option: Callable[[np.ndarray], None],
     process_image: Callable[[np.ndarray], np.ndarray],
     post_process_image: Callable[[np.ndarray], np.ndarray],
-    crop_size: int,
+    crop_size: int = 224,
     limit: int = None,
     **kwargs: Dict,
 ) -> None:

--- a/src/dot/dot.py
+++ b/src/dot/dot.py
@@ -92,7 +92,7 @@ class DOT:
             )
         elif swap_type == "fomm":
             option = self.fomm(
-                use_gpu=use_gpu, gpen_type=gpen_type, gpen_path=gpen_path
+                use_gpu=use_gpu, gpen_type=gpen_type, gpen_path=gpen_path, **kwargs
             )
         elif swap_type == "faceswap_cv2":
             option = self.faceswap_cv2(
@@ -198,7 +198,12 @@ class DOT:
         )
 
     def fomm(
-        self, use_gpu: bool, gpen_type: str, gpen_path: str, crop_size: int = 256
+        self,
+        use_gpu: bool,
+        gpen_type: str,
+        gpen_path: str,
+        crop_size: int = 256,
+        **kwargs,
     ) -> FOMMOption:
         """Build FOMM Option.
 
@@ -216,4 +221,5 @@ class DOT:
             gpen_type=gpen_type,
             gpen_path=gpen_path,
             crop_size=crop_size,
+            offline=self.use_video,
         )

--- a/src/dot/fomm/option.py
+++ b/src/dot/fomm/option.py
@@ -38,11 +38,12 @@ def determine_path():
 class FOMMOption(ModelOption):
     def __init__(
         self,
-        use_gpu=True,
-        use_mask=False,
-        crop_size=224,
-        gpen_type=None,
-        gpen_path=None,
+        use_gpu: bool = True,
+        use_mask: bool = False,
+        crop_size: int = 256,
+        gpen_type: str = None,
+        gpen_path: str = None,
+        offline: bool = False,
     ):
         super(FOMMOption, self).__init__(
             gpen_type=gpen_type,
@@ -50,6 +51,8 @@ class FOMMOption(ModelOption):
             crop_size=crop_size,
             gpen_path=gpen_path,
         )
+        # use FOMM offline, video or image file
+        self.offline = offline
         self.frame_proportion = 0.9
         self.frame_offset_x = 0
         self.frame_offset_y = 0
@@ -58,7 +61,7 @@ class FOMMOption(ModelOption):
         self.preview_flip = False
         self.output_flip = False
         self.find_keyframe = False
-        self.is_calibrated = False
+        self.is_calibrated = True if self.offline else False
 
         self.show_landmarks = False
         self.passthrough = False
@@ -76,7 +79,6 @@ class FOMMOption(ModelOption):
         self.display_string = ""
 
     def create_model(self, model_path, **kwargs) -> None:  # type: ignore
-
         opt_config = determine_path() + "/config/vox-adv-256.yaml"
         opt_checkpoint = model_path
 
@@ -157,7 +159,8 @@ class FOMMOption(ModelOption):
             log(key)
 
     def process_image(self, image, use_gpu=True, **kwargs) -> np.array:
-        self.handle_keyboard_input()
+        if not self.offline:
+            self.handle_keyboard_input()
 
         stream_img_size = image.shape[1], image.shape[0]
 
@@ -239,7 +242,8 @@ class FOMMOption(ModelOption):
         if not self.opt_hide_rect:
             draw_rect(preview_frame)
 
-        cv2.imshow("FOMM", preview_frame[..., ::-1])
+        if not self.offline:
+            cv2.imshow("FOMM", preview_frame[..., ::-1])
 
         if out is not None:
             if not self.opt_no_pad:


### PR DESCRIPTION
<!-- Is this pull request ready for review? (if not, please submit in draft mode) -->

## Description
Allows DOT.FOMM model to be used `offline` (without camera) with a given driving video.

### Changelog:

#### Added:

- dot/commons/pose/head_pose.py. Estimates whether desired head pose is achieved given Pitch, Roll and Yaw angles. 

#### Updated:

- dot/commons/model_option.py
- dot/fomm/option.py
- dot/dot.py
- dot/commons/video/video_utils.py
- dot/commons/utils.py
- dot/commons/model_option.py

### Usage:

`dot -c ./configs/fomm.yaml --target  /path/to/driving/video --source /path/to/source/image.png  --use_video --save_folder /output/folder/`
