### PR TITLE
Fix config paths in additional scripts under `scripts/` folder

### DIFF
--- a/scripts/image_swap.py
+++ b/scripts/image_swap.py
@@ -25,7 +25,7 @@ Usage:
 
 
 @click.command()
-@click.option("-c", "--config", default="./dot/simswap/configs/config.yaml")
+@click.option("-c", "--config", default="./src/dot/simswap/configs/config.yaml")
 @click.option("-s", "--source", required=True)
 @click.option("-t", "--target", required=True)
 @click.option("-o", "--save_folder", required=False)

--- a/scripts/metadata_swap.py
+++ b/scripts/metadata_swap.py
@@ -44,7 +44,7 @@ face_identity_features = {
 
 
 @click.command()
-@click.option("-c", "--config", default="./dot/simswap/configs/config.yaml")
+@click.option("-c", "--config", default="./src/dot/simswap/configs/config.yaml")
 @click.option("--local_root_path", required=True)
 @click.option("--metadata", required=True)
 @click.option("--set", required=True)

--- a/scripts/profile_simswap.py
+++ b/scripts/profile_simswap.py
@@ -15,7 +15,7 @@ import yaml
 import dot
 
 # define globals
-CONFIG = "./dot/simswap/configs/config.yaml"
+CONFIG = "./src/dot/simswap/configs/config.yaml"
 SOURCE = "data/obama.jpg"
 TARGET = "data/mona.jpg"
 SAVE_FOLDER = "./profile_output/"

--- a/scripts/video_swap.py
+++ b/scripts/video_swap.py
@@ -22,7 +22,7 @@ Usage:
 
 
 @click.command()
-@click.option("-c", "--config", default="./dot/simswap/configs/config.yaml")
+@click.option("-c", "--config", default="./src/dot/simswap/configs/config.yaml")
 @click.option("-s", "--source_image_path", required=True)
 @click.option("-t", "--target_video_path", required=True)
 @click.option("-o", "--output", required=True)


### PR DESCRIPTION
<!-- Is this pull request ready for review? (if not, please submit in draft mode) -->

## Description

Fixes #42

### Changelog:

#### Fixed:

- `scripts/image_swap.py`, `scripts/metadata_swap.py`, `scripts/profile_simswap.py` and `scripts/video_swap.py`
