### PR TITLE
Fix: Update instantiation of DOT class in scripts

### DIFF
--- a/scripts/image_swap.py
+++ b/scripts/image_swap.py
@@ -47,7 +47,7 @@ def main(
     with open(config) as f:
         config = yaml.safe_load(f)
 
-    _dot = dot.DOT(use_cam=False, use_video=False, save_folder=save_folder)
+    _dot = dot.DOT(use_video=False, use_image=True, save_folder=save_folder)
 
     analysis_config = config["analysis"]["simswap"]
     option = _dot.simswap(

--- a/scripts/profile_simswap.py
+++ b/scripts/profile_simswap.py
@@ -38,7 +38,7 @@ def main(
         config = yaml.safe_load(f)
 
     analysis_config = config["analysis"]["simswap"]
-    _dot = dot.DOT(use_cam=False, use_video=False, save_folder=save_folder)
+    _dot = dot.DOT(use_video=False, use_image=True, save_folder=save_folder)
     option = _dot.simswap(
         use_gpu=config["analysis"]["simswap"]["use_gpu"],
         gpen_type=config["analysis"]["simswap"]["gpen"],

--- a/scripts/video_swap.py
+++ b/scripts/video_swap.py
@@ -53,7 +53,7 @@ def main(
     with open(config) as f:
         config = yaml.safe_load(f)
 
-    _dot = dot.DOT(use_cam=False, use_video=True, save_folder=output)
+    _dot = dot.DOT(use_video=True, use_image=False, save_folder=output)
 
     analysis_config = config["analysis"]["simswap"]
     option = _dot.simswap(


### PR DESCRIPTION
## Description

### Changelog:
Updates the scripts in `scripts/` to pass `use_video` and `use_image` instead of `use_cam` when instantiating `DOT`.
#### Updated:

- Updated the instantiation parameters of `DOT` in `scripts/image_swap.py`, `scripts/video_swap.py` and `scripts/profile_simswap.py`.

#### Fixed:

- `ValueError` in `image_swap.py` caused by the `use_cam` attribute being set to `True`.